### PR TITLE
Add MIDI Program Change for waveform select and MIDI RT Toggle.

### DIFF
--- a/Firmware/midi-defs.h
+++ b/Firmware/midi-defs.h
@@ -25,7 +25,7 @@
 	#define MIDI_NOTE_ON				0x90
 	#define MIDI_NOTE_OFF				0x80
 	#define MIDI_AFTERTOUCH				0xA0
-	#define MIDI_CC						0xB0
+	#define MIDI_CC					0xB0
 	#define MIDI_PROGRAM				0xC0
 	#define MIDI_PRESSURE				0xD0
 	#define MIDI_PITCHBEND				0xE0
@@ -35,23 +35,26 @@
 	#define MIDI_SYSEX_END				0xF7
 
 /* MIDI - Realtime messages */
-	#define MIDI_TICK					0xF8
-	#define MIDI_START					0xFA
+	#define MIDI_TICK				0xF8
+	#define MIDI_START				0xFA
 	#define MIDI_CONTINUE				0xFB
-	#define MIDI_STOP					0xFC
+	#define MIDI_STOP				0xFC
 	#define MIDI_ACTIVESENSING			0xFE
 
 /* MIDI - Standard CC numbers */
 	#define MIDI_CC_MODWHEEL			1
 	#define MIDI_CC_VOLUME				7
 	#define MIDI_CC_BALANCE				8
-	#define MIDI_CC_PAN					10
+	#define MIDI_CC_PAN				10
 	#define MIDI_CC_EXPRESSION			11
 	#define MIDI_CC_RESONANCE			71
 	#define MIDI_CC_CUTOFF				74
 
+/* MIDI - Use 16 - General Purpose Controller 1 as Realtime message switch */
+	#define MIDI_CC_RTTOGGLE			16
+
 /* MIDI - Special CC numbers */
-	#define MIDI_CC_ALLSOUNDSOFF		120
+	#define MIDI_CC_ALLSOUNDSOFF			120
 	#define MIDI_CC_RESETCTRLS			121
 	#define MIDI_CC_ALLNOTESOFF			123
 	#define MIDI_CC_OMNIOFF				124

--- a/Firmware/midi.h
+++ b/Firmware/midi.h
@@ -27,6 +27,7 @@
 /******************************************************************************/
 	extern uint16_t midiBuffer[MIDIRX_BUFFER_LEN];
 	extern uint8_t midiChannel;
+	extern uint8_t midiRT;
 
 	void midiInit();
 	void midiUpdate();


### PR DESCRIPTION
Hi,

I wanted a way to change waveforms from my midi controller.
I also wanted a way to ignore RT messages, as I want to select whether I use the zekit seq or my midi seq.

Add MIDI Realtime message toggle using CC 16
    0 = ignore RT messages
  \> 0 = apply RT messages (default)

This builds, although I haven't been able to get it programmed into the PIC yet for testing.  
Please review and comment.